### PR TITLE
use correct framework

### DIFF
--- a/RevitAddinMultiVersion/RevitAddinMultiVersion.csproj
+++ b/RevitAddinMultiVersion/RevitAddinMultiVersion.csproj
@@ -15,12 +15,12 @@
           2022  |  net48
           2023  |  net48
           2024  |  net48
-          2025  |  net80
+          2025  |  net8.0
         -->
         
         <LangVersion>latest</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
-        <TargetFramework>net80</TargetFramework> <!-- Default .NET Framework -->
+        <TargetFramework>net8.0</TargetFramework> <!-- Default .NET Framework -->
 
         <Configurations>Debug R14;Debug R15;Debug R16;Debug R17;Debug R18;Debug R19;Debug R20;Debug R21;Debug R22;Debug R23;Debug R24;Debug R25</Configurations>
         <Configurations>$(Configurations);Release R14;Release R15;Release R16;Release R17;Release R18;Release R19;Release R20;Release R21;Release R22;Release R23;Release R24;Release R25</Configurations>
@@ -95,7 +95,7 @@
     
     <PropertyGroup Condition="$(Configuration.Contains('R25'))">
         <RevitVersion>2025</RevitVersion>
-        <TargetFramework>net80</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <DefineConstants>REVIT2025;WINFORMS</DefineConstants>
     </PropertyGroup>
 

--- a/RevitAddinMultiVersion/build-release.bat
+++ b/RevitAddinMultiVersion/build-release.bat
@@ -25,6 +25,6 @@ zstd -f -19 -T0 -v "bin\Any CPU\Release R21\net48\RevitAddinMultiVersion.dll" -o
 zstd -f -19 -T0 -v "bin\Any CPU\Release R22\net48\RevitAddinMultiVersion.dll" -o "bin\RevitAddinMultiVersionR22.zstd"
 zstd -f -19 -T0 -v "bin\Any CPU\Release R23\net48\RevitAddinMultiVersion.dll" -o "bin\RevitAddinMultiVersionR23.zstd"
 zstd -f -19 -T0 -v "bin\Any CPU\Release R24\net48\RevitAddinMultiVersion.dll" -o "bin\RevitAddinMultiVersionR24.zstd"
-zstd -f -19 -T0 -v "bin\Any CPU\Release R25\net80\RevitAddinMultiVersion.dll" -o "bin\RevitAddinMultiVersionR25.zstd"
+zstd -f -19 -T0 -v "bin\Any CPU\Release R25\net8.0\RevitAddinMultiVersion.dll" -o "bin\RevitAddinMultiVersionR25.zstd"
 
 endlocal

--- a/RevitAddinMultiVersion/build.bat
+++ b/RevitAddinMultiVersion/build.bat
@@ -25,6 +25,6 @@ zstd -f -19 -T0 -v "bin\Any CPU\Debug R21\net48\RevitAddinMultiVersion.dll" -o "
 zstd -f -19 -T0 -v "bin\Any CPU\Debug R22\net48\RevitAddinMultiVersion.dll" -o "bin\RevitAddinMultiVersionR22.zstd"
 zstd -f -19 -T0 -v "bin\Any CPU\Debug R23\net48\RevitAddinMultiVersion.dll" -o "bin\RevitAddinMultiVersionR23.zstd"
 zstd -f -19 -T0 -v "bin\Any CPU\Debug R24\net48\RevitAddinMultiVersion.dll" -o "bin\RevitAddinMultiVersionR24.zstd"
-zstd -f -19 -T0 -v "bin\Any CPU\Debug R25\net80\RevitAddinMultiVersion.dll" -o "bin\RevitAddinMultiVersionR25.zstd"
+zstd -f -19 -T0 -v "bin\Any CPU\Debug R25\net8.0\RevitAddinMultiVersion.dll" -o "bin\RevitAddinMultiVersionR25.zstd"
 
 endlocal

--- a/RevitAddinMultiVersion/build.sh
+++ b/RevitAddinMultiVersion/build.sh
@@ -22,7 +22,7 @@ zstd -f -19 -T0 -v bin/Any\ CPU/Debug\ R21/net48/RevitAddinMultiVersion.dll -o b
 zstd -f -19 -T0 -v bin/Any\ CPU/Debug\ R22/net48/RevitAddinMultiVersion.dll -o bin/RevitAddinMultiVersionR22.zstd
 zstd -f -19 -T0 -v bin/Any\ CPU/Debug\ R23/net48/RevitAddinMultiVersion.dll -o bin/RevitAddinMultiVersionR23.zstd
 zstd -f -19 -T0 -v bin/Any\ CPU/Debug\ R24/net48/RevitAddinMultiVersion.dll -o bin/RevitAddinMultiVersionR24.zstd
-zstd -f -19 -T0 -v bin/Any\ CPU/Debug\ R25/net80/RevitAddinMultiVersion.dll -o bin/RevitAddinMultiVersionR25.zstd
+zstd -f -19 -T0 -v bin/Any\ CPU/Debug\ R25/net8.0/RevitAddinMultiVersion.dll -o bin/RevitAddinMultiVersionR25.zstd
 
 
 #
@@ -39,7 +39,7 @@ zstd -f -19 -T0 -v bin/Any\ CPU/Debug\ R25/net80/RevitAddinMultiVersion.dll -o b
 #    bin/Any\ CPU/Debug\ R22/net48/RevitAddinMultiVersion.dll \
 #    bin/Any\ CPU/Debug\ R23/net48/RevitAddinMultiVersion.dll \
 #    bin/Any\ CPU/Debug\ R24/net48/RevitAddinMultiVersion.dll \
-#    bin/Any\ CPU/Debug\ R25/net80/RevitAddinMultiVersion.dll \
+#    bin/Any\ CPU/Debug\ R25/net8.0/RevitAddinMultiVersion.dll \
 #    /lib:bin/Any\ CPU/Debug\ R14/net40 \
 #    /lib:bin/Any\ CPU/Debug\ R15/net45 \
 #    /lib:bin/Any\ CPU/Debug\ R16/net451 \
@@ -51,6 +51,6 @@ zstd -f -19 -T0 -v bin/Any\ CPU/Debug\ R25/net80/RevitAddinMultiVersion.dll -o b
 #    /lib:bin/Any\ CPU/Debug\ R22/net48 \
 #    /lib:bin/Any\ CPU/Debug\ R23/net48 \
 #    /lib:bin/Any\ CPU/Debug\ R24/net48 \
-#    /lib:bin/Any\ CPU/Debug\ R25/net80 \
+#    /lib:bin/Any\ CPU/Debug\ R25/net8.0 \
 #    /internalize
 


### PR DESCRIPTION
the undocumented names (without period in dotnet 5+) can drop their support when move to double-digit (to avoid potential conflicts) [learn.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks](https://learn.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks)